### PR TITLE
Fix: Support interface type hints in dependency resolution

### DIFF
--- a/src/ShellAbstract.php
+++ b/src/ShellAbstract.php
@@ -105,8 +105,8 @@ abstract class ShellAbstract
             $params = $reflection->getParameters();
             $arguments = [];
             foreach ($params as $param) {
-                if (!class_exists($param->getType()->getName())) {
-                    throw new RuntimeException(sprintf('Class "%s" not found', $param->getType()->getName()));
+                if (!class_exists($param->getType()->getName()) && !interface_exists($param->getType()->getName())) {
+                    throw new RuntimeException(sprintf('Dependency "%s" not found', $param->getType()->getName()));
                 }
                 $arguments[] = $this->getInstance($param->getType()->getName());
             }


### PR DESCRIPTION
Prevents a fatal error when a parameter has an interface type hint.

Previously, only class_exists() was used to validate the existence of the type, which failed for interfaces like Psr\Log\LoggerInterface. The check is now extended to include interface_exists().